### PR TITLE
[build] macOS support (without trivial-main-thread)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.fasl
 *.fas
 *.so
+*.dylib
 lib/
+raylib.h
+shim.h

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,14 @@ lib/lisp-raylib.dll:
 lib/lisp-raylib-shim.dll: c/shim.c c/raylib.h
 	cd c && x86_64-w64-mingw32-gcc -L"../lib" -llisp-raylib -O3 -fPIC -shared -o lisp-raylib-shim.dll shim.c
 	mv c/lisp-raylib-shim.dll lib/
+
+# --- MacOS --- #
+
+macos: lib/ lib/liblisp-raylib.dylib lib/liblisp-raylib-shim.dylib raylib.h shim.h
+
+lib/liblisp-raylib.dylib:
+	cd vendored/raylib-c/src/ && $(MAKE) PLATFORM=$(PLATFORM)
+	cp vendored/raylib-c/src/liblisp-raylib.5.5.0.dylib lib/liblisp-raylib.dylib
+
+lib/liblisp-raylib-shim.dylib: c/shim.c lib/liblisp-raylib.dylib
+	$(CC) -O3 -fPIC -dynamiclib -o lib/liblisp-raylib-shim.dylib c/shim.c -Ivendored/raylib-c/src/ -Llib/ -llisp-raylib -Wl,-rpath,@loader_path

--- a/README.org
+++ b/README.org
@@ -328,5 +328,24 @@ clean:
 
 This copies the underlying =.so= files into a =lib/= local to your application, so
 that when the =raylib= system loads, it will find them where it expects.
+** macOS
+On macOS the window must be created on the main thread. This can be accomplished
+using `trivial-main-thread` with something like:
+
+#+begin_src common-lisp
+  (defun launch ()
+    (raylib:init-window +screen-width+ +screen-height+ "My Game")
+    ;; Game loop, drawing etc ...
+    )
+
+  (defun main ()
+    ,#+darwin
+    (trivial-main-thread:with-body-in-main-thread ()
+      ,#+sbcl
+      (sb-int:set-floating-point-modes :traps '())
+      (launch))
+    #-darwin
+    (launch))
+#+end_src
 
 ** Creating Release Builds

--- a/lisp/package.lisp
+++ b/lisp/package.lisp
@@ -49,6 +49,8 @@ restarted. Note the use of `:dont-save' below. This is to allow the package to
 be compiled with `.so' files found in one location, but run with ones from another."
   (let ((dir (case target
                (:linux "/usr/lib/")
+               (:darwin #+arm64 "/opt/homebrew/lib/"
+                        #-arm64 "/usr/local/lib/")
                (t "lib/"))))
     #+linux
     (progn
@@ -57,7 +59,11 @@ be compiled with `.so' files found in one location, but run with ones from anoth
     #+win32
     (progn
       (load-shared-object (merge-pathnames "lisp-raylib.dll" dir) :dont-save t)
-      (load-shared-object (merge-pathnames "lisp-raylib-shim.dll" dir) :dont-save t))))
+      (load-shared-object (merge-pathnames "lisp-raylib-shim.dll" dir) :dont-save t))
+    #+darwin
+    (progn
+      (load-shared-object (merge-pathnames "liblisp-raylib.dylib" dir) :dont-save t)
+      (load-shared-object (merge-pathnames "liblisp-raylib-shim.dylib" dir) :dont-save t))))
 
 #+sbcl
 (load-shared-objects)
@@ -68,6 +74,11 @@ be compiled with `.so' files found in one location, but run with ones from anoth
 (progn
   (ffi:load-foreign-library #p"lib/liblisp-raylib.so")
   (ffi:load-foreign-library #p"lib/liblisp-raylib-shim.so"))
+
+#+(and ecl darwin)
+(progn
+  (ffi:load-foreign-library #p"lib/liblisp-raylib.dylib")
+  (ffi:load-foreign-library #p"lib/liblisp-raylib-shim.dylib"))
 
 ;; --- Keyboard and Gamepad --- ;;
 


### PR DESCRIPTION
This is identical to #2 except with the `trivial-main-thread` parts reverted and an update to the README. Further to https://github.com/fosskers/raylib/pull/2#discussion_r2700169305, I can confirm that it works on my MacBook. I found that I also had to disable the floating point traps when running with SBCL.

Thanks @fosskers for this fantastic library and @takeiteasy for the initial macOS support.